### PR TITLE
init to 1.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "cloudevents" %}
+{% set version = "1.10.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cloudevents-{{ version }}.tar.gz
+  sha256: 984d90aa114deeb1c37ceecf78f9dc9d56f5866cf10b45142a23c84d22621ac9
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - deprecation >=2.0,<3.0
+  run_constrained:
+    - pydantic >=1.0.0,<3.0
+
+test:
+  imports:
+    - cloudevents
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/cloudevents/sdk-python
+  summary: CloudEvents Python SDK
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  dev_url: https://github.com/cloudevents/sdk-python
+  doc_url: https://github.com/cloudevents/sdk-python
+
+extra:
+  recipe-maintainers:
+    - cbouss


### PR DESCRIPTION
cloudevents 1.10.1

**Destination channel:** ai-staging

### Links

- [PKG-4016](https://anaconda.atlassian.net/browse/PKG-4016) 
- https://github.com/cloudevents/sdk-python

### Explanation of changes:
- New feedstock on ai-staging. Keeping as noarch for ease of maintenance.


[PKG-4016]: https://anaconda.atlassian.net/browse/PKG-4016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ